### PR TITLE
Changed the target object to prevent clicking when drag & drop

### DIFF
--- a/addon/mixins/sortable-item.js
+++ b/addon/mixins/sortable-item.js
@@ -654,7 +654,8 @@ export default Mixin.create({
   _drop() {
     if (!this.element || !this.$()) { return; }
 
-    this._preventClick(this.element);
+    let element = this.get('handle') ? this.$(this.get('handle')) : this.$();
+    this._preventClick(element);
 
     this.set('isDragging', false);
     this.set('isDropping', true);


### PR DESCRIPTION
После перетаскивания на целевом объекте создается и продолжает вистеть event listener (защита от клика), из-за чего не работают кнопки на этом объекте в ff.
Исправлено изменением объекта, на который вешается это событие - `handle`